### PR TITLE
ci: bump GitHub Actions to current majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8.1.0
         with:
           python-version: "3.12"
       - run: uv sync --extra dev
@@ -37,8 +37,8 @@ jobs:
       matrix:
         python-version: ["3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8.1.0
         with:
           python-version: ${{ matrix.python-version }}
       - run: uv sync --extra dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,10 +45,10 @@ jobs:
     needs: determine
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0  # hatch-vcs needs the full history to resolve the tag
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Install build tooling
@@ -64,7 +64,7 @@ jobs:
           echo "Tag expects: $expected"
           echo "Wheel reports: $built"
           test "$expected" = "$built"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
@@ -82,7 +82,7 @@ jobs:
       attestations: write  # PEP 740 build provenance
       contents: read
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
@@ -100,8 +100,8 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
@@ -120,7 +120,7 @@ jobs:
             echo "Release $TAG — see CHANGELOG.md for details." > release-notes.md
           fi
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}


### PR DESCRIPTION
Removes the Node 20 deprecation warning by moving to current action majors (Node 24 runtimes).

**ci.yml** (validated by this PR's run): `actions/checkout` v4→v6, `astral-sh/setup-uv` v5→v8.

**release.yml** (only runs on tag; bumped for parity, not exercised here): `checkout` v6, `setup-python` v6, `upload-artifact` v4→v7, `download-artifact` v4→v8, `softprops/action-gh-release` v2→v3. `pypa/gh-action-pypi-publish` left at `release/v1` (its recommended pin). Worth a sanity check on the next release tag.